### PR TITLE
Add imports to filter_transformations (issue #17)

### DIFF
--- a/notebooks/filter_transformations/filter_transformations.ipynb
+++ b/notebooks/filter_transformations/filter_transformations.ipynb
@@ -86,7 +86,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
+    "import astropy.units as u\n",
+    "import synphot.units as su\n",
     "import synphot as syn\n",
     "from synphot import Observation\n",
     "\n",
@@ -560,7 +561,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -574,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Imports two additional modules in the `filter_transformations` notebook. Closes https://github.com/spacetelescope/WFC3Library/issues/17.