### PR TITLE
Fix reference file links; specify overwrite behavior for writing tables

### DIFF
--- a/notebooks/zeropoints/zeropoints.ipynb
+++ b/notebooks/zeropoints/zeropoints.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O ftp://archive.stsci.edu/pub/hst/pysynphot/synphot1.tar.gz'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },
@@ -477,14 +477,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def calculate_bands(bp, save=False):\n",
+    "def calculate_bands(bp, save=False, overwrite=True):\n",
     "    # Pass in bandpass object as bp\n",
     "    waves = bp.waveset\n",
     "    throughput = bp(waves)\n",
     "    \n",
     "    if save:\n",
     "        tmp = Table([waves, throughput], names=['WAVELENGTH', 'THROUGHPUT'])\n",
-    "        tmp.write(','.join(bp.obsmode.modes)+'.txt', format='ascii.commented_header')\n",
+    "        tmp.write(','.join(bp.obsmode.modes)+'.txt', format='ascii.commented_header', overwrite=overwrite)\n",
     "        \n",
     "    return (waves, throughput)"
    ]


### PR DESCRIPTION
Updates the reference file link (fixes #15)

Also adds a default value of `overwrite=True` in the function `calculate_bands` for saving the table, which prevents an Astropy warning from appearing. 