### PR TITLE
Synphot reffile fixes

### DIFF
--- a/notebooks/filter_transformations/filter_transformations.ipynb
+++ b/notebooks/filter_transformations/filter_transformations.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },
@@ -561,7 +561,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -575,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/filter_transformations/filter_transformations.ipynb
+++ b/notebooks/filter_transformations/filter_transformations.ipynb
@@ -99,7 +99,7 @@
    "id": "c7a66046",
    "metadata": {},
    "source": [
-    "This section obtains the WFC3 throughput component tables for use with `stsynphot`. If the reference files need to be downloaded, please uncomment and execute the code block below."
+    "This section obtains the WFC3 throughput component tables for use with `stsynphot`. If the reference files need to be downloaded, please uncomment and execute the code block below. "
    ]
   },
   {
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v11_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },

--- a/notebooks/flux_conversion_tool/flux_conversion_tool.ipynb
+++ b/notebooks/flux_conversion_tool/flux_conversion_tool.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v11_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },

--- a/notebooks/flux_conversion_tool/flux_conversion_tool.ipynb
+++ b/notebooks/flux_conversion_tool/flux_conversion_tool.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },
@@ -869,7 +869,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/photometry_examples/phot_examples.ipynb
+++ b/notebooks/photometry_examples/phot_examples.ipynb
@@ -113,7 +113,7 @@
    "id": "06d98189",
    "metadata": {},
    "source": [
-    "This section obtains the WFC3 throughput component tables for use with `synphot`. If reference files need to be downloaded, please uncomment and execute the code block below."
+    "This section obtains the WFC3 throughput component tables for use with `stsynphot`. If these reference files need to be downloaded, please uncomment and execute the code block below."
    ]
   },
   {
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v11_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },
@@ -132,7 +132,7 @@
    "id": "054629f8",
    "metadata": {},
    "source": [
-    "Once the downloaded is complete, unzip the file and set the environment variable `PYSYN_CDBS` to the path of the reference files. To do so, uncomment and execute the relevant line from the code block below. "
+    "Once the downloaded is complete, unzip the files and consolidate the contents of the \"trds\" subdirectories. Set the environment variable `PYSYN_CDBS` to the path of this combined directory. That is, you should have a directory somewhere called `trds` that contains the `comp`, `mtab`, and `calspec` subdirectories, and set the environment variable to the path to this directory. To do so, uncomment and execute the relevant line from the code block below. "
    ]
   },
   {
@@ -142,7 +142,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# os.environ['PYSYN_CDBS'] = '/path/to/my/reference/files/'"
+    "os.environ['PYSYN_CDBS'] = '/Users/apidgeon/Desktop/grp/redcat/trds'\n",
+    "# os.environ['PYSYN_CDBS'] = '/path/to/location/of/trds'"
    ]
   },
   {

--- a/notebooks/photometry_examples/phot_examples.ipynb
+++ b/notebooks/photometry_examples/phot_examples.ipynb
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },
@@ -870,7 +870,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/zeropoints/zeropoints.ipynb
+++ b/notebooks/zeropoints/zeropoints.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v10_sed.tar'\n",
+    "# cmd_input = 'curl -O https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v11_sed.tar'\n",
     "# os.system(cmd_input)"
    ]
   },
@@ -643,7 +643,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -657,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated links to throughput table .tar files for `stsynphot`. A user was having further difficulty in [this helpdesk ticket](https://stsci.service-now.com/nav_to.do?uri=%2Fincident.do%3Fsys_id%3Dfb1d430a9739511444d5f6a3f153af0d%26sysparm_record_list%3Dcompany%253d%255eORwatch_listCONTAINS11f33ca11bccb450e4c6edb0604bcb82%255eORcompany%253d02267202dbec760033b55dd5ce9619a9%255eORcaller_id%253d11f33ca11bccb450e4c6edb0604bcb82%255eORopened_by%253d11f33ca11bccb450e4c6edb0604bcb82%255eORDERBYDESCsys_updated_on%26sysparm_record_row%3D4%26sysparm_record_rows%3D5012%26sysparm_record_target%3Dincident%26sysparm_view%3DHST%26sysparm_view_forced%3Dtrue), but it seems their particular case had some other issue that was unable to be resolved. These links should provide the most recent throughput tables, with the only other required file being the Vega spectrum, which is included as part of the base `synphot` package